### PR TITLE
feat: update regular comment syntax, add block comment

### DIFF
--- a/syntax/cook.vim
+++ b/syntax/cook.vim
@@ -29,7 +29,8 @@ syntax match cookTimer "\~[^{]\{-}{[^}]*}"
 
 " Comments
 syntax keyword cookTodo contained TODO FIXME NOTE
-syntax match cookComment "//.*$" contains=cookTodo
+syntax match cookComment "--.*$" contains=cookTodo
+syntax match cookBlockComment "\[[^\]]*\]" contains=cookTodo
 
 highlight def link cookUnit Label
 highlight def link cookNumbers Number
@@ -44,5 +45,6 @@ highlight def link cookCookware Type
 highlight def link cookTimer Number
 highlight def link cookTodo Todo
 highlight def link cookComment Comment
+highlight def link cookBlockComment Comment
 
 let b:current_syntax = 'cook'


### PR DESCRIPTION
Hello, @luizribeiro. Thank you for your work on this plugin for cooklang.

This change updates the regular comment expression to support the current cooklang spec. It also adds support for the new block comments.

Summary:

|           Description           |           Example          |
|:-------------------------------:|:--------------------------:|
| Removed previous comment syntax |   `// This is a comment`   |
|      Added comment syntax       |   `-- This is a comment`   |
|   Added block comment syntax    |  `[- this is a comment -]` |

Resolves: #1